### PR TITLE
Gating PR feedback

### DIFF
--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -10,7 +10,7 @@ Vitessce supports several __view types__ for visualization of single-cell data, 
 ### `scatterplot`
 
 The scatterplot view displays 2-dimensional (pre-computed) embeddings / projections (such as t-SNE or UMAP).
-Use with the `embeddingType` coordination type to specify which embedding to use when mapping cells onto scatterplot points. If no embedding is specified, users can choose a mapping from any mappings that are available.
+Use with the `embeddingType` coordination type to specify which embedding to use when mapping cells onto scatterplot points. If no embedding is specified, users can choose an `embeddingType` from any that are available.
 Use with datasets containing the `cells` data type. Optionally, the `cell-sets` and `genes` data types can be used for coloring cells on the plot.
 
 <ComponentImage filename="scatterplot-2.png" alt="Screenshot of Scatterplot View" />

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -110,6 +110,5 @@ export const CoordinationType = {
   MOLECULE_HIGHLIGHT: 'moleculeHighlight',
   GATING_FEATURE_SELECTION_X: 'gatingFeatureSelectionX',
   GATING_FEATURE_SELECTION_Y: 'gatingFeatureSelectionY',
-  GATING_FEATURE_VALUE_TRANSFORM: 'gatingFeatureValueTransform',
-  GATING_FEATURE_VALUE_TRANSFORM_COEFFICIENT: 'gatingFeatureValueTransformCoefficient',
+  FEATURE_VALUE_TRANSFORM_COEFFICIENT: 'featureValueTransformCoefficient',
 };

--- a/src/app/state/coordination.js
+++ b/src/app/state/coordination.js
@@ -43,6 +43,7 @@ export const DEFAULT_COORDINATION_VALUES = {
   [CoordinationType.FEATURE_VALUE_COLORMAP]: 'plasma',
   [CoordinationType.FEATURE_VALUE_COLORMAP_RANGE]: [0.0, 1.0],
   [CoordinationType.FEATURE_VALUE_TRANSFORM]: null,
+  [CoordinationType.FEATURE_VALUE_TRANSFORM_COEFFICIENT]: 1,
   [CoordinationType.FEATURE_FILTER]: null,
   [CoordinationType.FEATURE_HIGHLIGHT]: null,
   [CoordinationType.FEATURE_SELECTION]: null,
@@ -60,8 +61,6 @@ export const DEFAULT_COORDINATION_VALUES = {
   [CoordinationType.MOLECULE_HIGHLIGHT]: null,
   [CoordinationType.GATING_FEATURE_SELECTION_X]: null,
   [CoordinationType.GATING_FEATURE_SELECTION_Y]: null,
-  [CoordinationType.GATING_FEATURE_VALUE_TRANSFORM]: null,
-  [CoordinationType.GATING_FEATURE_VALUE_TRANSFORM_COEFFICIENT]: 1,
 };
 
 // The following coordination types should be
@@ -154,8 +153,8 @@ export const COMPONENT_COORDINATION_TYPES = {
     CoordinationType.FEATURE_VALUE_COLORMAP_RANGE,
     CoordinationType.OBS_COLOR_ENCODING,
     CoordinationType.ADDITIONAL_OBS_SETS,
-    CoordinationType.GATING_FEATURE_VALUE_TRANSFORM,
-    CoordinationType.GATING_FEATURE_VALUE_TRANSFORM_COEFFICIENT,
+    CoordinationType.FEATURE_VALUE_TRANSFORM,
+    CoordinationType.FEATURE_VALUE_TRANSFORM_COEFFICIENT,
     CoordinationType.GATING_FEATURE_SELECTION_X,
     CoordinationType.GATING_FEATURE_SELECTION_Y,
   ],
@@ -255,6 +254,7 @@ export const COMPONENT_COORDINATION_TYPES = {
     CoordinationType.FEATURE_VALUE_TYPE,
     CoordinationType.FEATURE_SELECTION,
     CoordinationType.FEATURE_VALUE_TRANSFORM,
+    CoordinationType.FEATURE_VALUE_TRANSFORM_COEFFICIENT,
     CoordinationType.OBS_SET_SELECTION,
     CoordinationType.OBS_SET_HIGHLIGHT,
     CoordinationType.OBS_SET_COLOR,

--- a/src/app/state/coordination.js
+++ b/src/app/state/coordination.js
@@ -60,7 +60,7 @@ export const DEFAULT_COORDINATION_VALUES = {
   [CoordinationType.MOLECULE_HIGHLIGHT]: null,
   [CoordinationType.GATING_FEATURE_SELECTION_X]: null,
   [CoordinationType.GATING_FEATURE_SELECTION_Y]: null,
-  [CoordinationType.GATING_FEATURE_VALUE_TRANSFORM]: '',
+  [CoordinationType.GATING_FEATURE_VALUE_TRANSFORM]: null,
   [CoordinationType.GATING_FEATURE_VALUE_TRANSFORM_COEFFICIENT]: 1,
 };
 

--- a/src/app/view-config-upgraders.js
+++ b/src/app/view-config-upgraders.js
@@ -442,8 +442,7 @@ export function upgradeFrom1_0_12(config) {
 // - Adds the coordination types
 // gatingFeatureSelectionX,
 // gatingFeatureSelectionY,
-// gatingFeatureValueTransform,
-// gatingFeatureValueTransformCoefficient.
+// featureValueTransformCoefficient.
 export function upgradeFrom1_0_13(config) {
   const newConfig = cloneDeep(config);
 

--- a/src/app/view-config-upgraders.js
+++ b/src/app/view-config-upgraders.js
@@ -437,3 +437,18 @@ export function upgradeFrom1_0_12(config) {
     version: '1.0.13',
   };
 }
+
+// Added in version 1.0.14:
+// - Adds the coordination types
+// gatingFeatureSelectionX,
+// gatingFeatureSelectionY,
+// gatingFeatureValueTransform,
+// gatingFeatureValueTransformCoefficient.
+export function upgradeFrom1_0_13(config) {
+  const newConfig = cloneDeep(config);
+
+  return {
+    ...newConfig,
+    version: '1.0.14',
+  };
+}

--- a/src/app/view-config-versions.js
+++ b/src/app/view-config-versions.js
@@ -15,6 +15,7 @@ import configSchema1_0_10 from '../schemas/config-1.0.10.schema.json';
 import configSchema1_0_11 from '../schemas/config-1.0.11.schema.json';
 import configSchema1_0_12 from '../schemas/config-1.0.12.schema.json';
 import configSchema1_0_13 from '../schemas/config-1.0.13.schema.json';
+import configSchema1_0_14 from '../schemas/config-1.0.14.schema.json';
 import cellSetsSchema from '../schemas/cell-sets.schema.json';
 import rasterSchema from '../schemas/raster.schema.json';
 import {
@@ -32,6 +33,7 @@ import {
   upgradeFrom1_0_10,
   upgradeFrom1_0_11,
   upgradeFrom1_0_12,
+  upgradeFrom1_0_13,
 } from './view-config-upgraders';
 
 /**
@@ -39,7 +41,7 @@ import {
  * Add a new schema and upgrade function here when bumping the view config version.
  * The latest view config version should always have a null value instead of an upgrade function.
  */
-export const LATEST_VERSION = '1.0.13';
+export const LATEST_VERSION = '1.0.14';
 export const SCHEMA_HANDLERS = {
   '0.1.0': [new Ajv().compile(configSchema0_1_0), upgradeFrom0_1_0],
   '1.0.0': [new Ajv().addSchema(cellSetsSchema).addSchema(rasterSchema).compile(configSchema1_0_0), upgradeFrom1_0_0],
@@ -55,5 +57,6 @@ export const SCHEMA_HANDLERS = {
   '1.0.10': [new Ajv().addSchema(cellSetsSchema).addSchema(rasterSchema).compile(configSchema1_0_10), upgradeFrom1_0_10],
   '1.0.11': [new Ajv().addSchema(cellSetsSchema).addSchema(rasterSchema).compile(configSchema1_0_11), upgradeFrom1_0_11],
   '1.0.12': [new Ajv().addSchema(cellSetsSchema).addSchema(rasterSchema).compile(configSchema1_0_12), upgradeFrom1_0_12],
-  '1.0.13': [new Ajv().addSchema(cellSetsSchema).addSchema(rasterSchema).compile(configSchema1_0_13), null],
+  '1.0.13': [new Ajv().addSchema(cellSetsSchema).addSchema(rasterSchema).compile(configSchema1_0_13), upgradeFrom1_0_13],
+  '1.0.14': [new Ajv().addSchema(cellSetsSchema).addSchema(rasterSchema).compile(configSchema1_0_14), null],
 };

--- a/src/components/embedding-scatterplot/EmbeddingScatterplotOptions.js
+++ b/src/components/embedding-scatterplot/EmbeddingScatterplotOptions.js
@@ -14,7 +14,7 @@ export default function EmbeddingScatterplotOptions(props) {
 
   const classes = useStyles();
 
-  const mappingSelectOptions = ['', ...Object.keys(mappings)];
+  const mappingSelectOptions = mappings;
 
   // Handlers for custom option field changes.
   const handleSelectedMappingChange = (event) => {
@@ -25,7 +25,7 @@ export default function EmbeddingScatterplotOptions(props) {
     ? (
       <TableRow key="mapping-option-row">
         <TableCell className={classes.labelCell}>
-      Mapping
+          Embedding Type
         </TableCell>
         <TableCell className={classes.inputCell}>
           <OptionSelect

--- a/src/components/embedding-scatterplot/EmbeddingScatterplotOptions.js
+++ b/src/components/embedding-scatterplot/EmbeddingScatterplotOptions.js
@@ -14,8 +14,6 @@ export default function EmbeddingScatterplotOptions(props) {
 
   const classes = useStyles();
 
-  const mappingSelectOptions = mappings;
-
   // Handlers for custom option field changes.
   const handleSelectedMappingChange = (event) => {
     setSelectedMapping(event.target.value);
@@ -37,7 +35,7 @@ export default function EmbeddingScatterplotOptions(props) {
               id: 'scatterplot-mapping-select',
             }}
           >
-            {mappingSelectOptions.map(name => (
+            {mappings.map(name => (
               <option key={name} value={name}>
                 {name}
               </option>

--- a/src/components/embedding-scatterplot/EmbeddingScatterplotSubscriber.js
+++ b/src/components/embedding-scatterplot/EmbeddingScatterplotSubscriber.js
@@ -32,7 +32,7 @@ export default function EmbeddingScatterplotSubscriber(props) {
   const {
     coordinationScopes,
     title: titleOverride,
-    enableEmbeddingTypeSelection = false,
+    enableEmbeddingTypeSelection = true,
   } = props;
 
   // Get "props" from the coordination space.
@@ -62,7 +62,7 @@ export default function EmbeddingScatterplotSubscriber(props) {
 
   const customOptions = (
     <EmbeddingScatterplotOptions
-      mappingSelectEnabled={enableEmbeddingTypeSelection}
+      mappingSelectEnabled={enableEmbeddingTypeSelection && availableEmbeddingTypes?.length > 1}
       mappings={availableEmbeddingTypes}
       selectedMapping={embeddingType}
       setSelectedMapping={setEmbeddingType}

--- a/src/components/embedding-scatterplot/EmbeddingScatterplotSubscriber.js
+++ b/src/components/embedding-scatterplot/EmbeddingScatterplotSubscriber.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import ScatterplotSubscriber, {
   SCATTERPLOT_DATA_TYPES,
 } from '../scatterplot/ScatterplotSubscriber';
@@ -10,6 +10,7 @@ import { useReady, useUrls } from '../hooks';
 import { useCellsData } from '../data-hooks';
 import { COMPONENT_COORDINATION_TYPES } from '../../app/state/coordination';
 import EmbeddingScatterplotOptions from './EmbeddingScatterplotOptions';
+import { Component } from '../../app/constants';
 
 /**
    * A subscriber component for the cell mapping scatterplot.
@@ -29,11 +30,15 @@ export default function EmbeddingScatterplotSubscriber(props) {
   const {
     coordinationScopes,
     title: titleOverride,
+    enableEmbeddingTypeSelection = true,
   } = props;
 
   // Get "props" from the coordination space.
-  const [{ dataset, embeddingType: mapping }] = useCoordination(
-    COMPONENT_COORDINATION_TYPES.scatterplot,
+  const [
+    { dataset, embeddingType },
+    { setEmbeddingType },
+  ] = useCoordination(
+    COMPONENT_COORDINATION_TYPES[Component.SCATTERPLOT],
     coordinationScopes,
   );
 
@@ -43,46 +48,40 @@ export default function EmbeddingScatterplotSubscriber(props) {
   const [isReady, setItemIsReady, setItemIsNotReady, resetReadyItems] = useReady(
     SCATTERPLOT_DATA_TYPES,
   );
-  const [cells, cellsCount] = useCellsData(loaders, dataset, setItemIsReady, addUrl, true);
+  const cellsData = useCellsData(loaders, dataset, setItemIsReady, addUrl, true);
 
-
-  const [selectedMapping, setSelectedMapping] = React.useState('');
-
-
-  let optionMappings = {};
-  const cellIds = Object.keys(cells);
-  if (!mapping && cellIds.length !== 0) {
-    optionMappings = cells[cellIds[0]].mappings;
-  }
+  const availableEmbeddingTypes = useMemo(() => {
+    const cellObjs = Object.values(cellsData?.[0] || {});
+    if (cellObjs.length !== 0) {
+      return Object.keys(cellObjs[0].mappings);
+    }
+    return null;
+  }, [cellsData]);
 
   const customOptions = (
     <EmbeddingScatterplotOptions
-      mappingSelectEnabled={!mapping}
-      mappings={optionMappings}
-      selectedMapping={selectedMapping}
-      setSelectedMapping={setSelectedMapping}
+      mappingSelectEnabled={enableEmbeddingTypeSelection}
+      mappings={availableEmbeddingTypes}
+      selectedMapping={embeddingType}
+      setSelectedMapping={setEmbeddingType}
     />
   );
 
-  const plotMapping = mapping || selectedMapping;
-  // Set cells to empty if no mapping is provided so that nothing is plotted.
-  const plotCells = plotMapping ? cells : {};
-
-  const defaultTitle = plotMapping ? `Scatterplot (${plotMapping})` : 'Scatterplot';
+  const defaultTitle = embeddingType ? `Scatterplot (${embeddingType})` : 'Scatterplot';
   const title = titleOverride || defaultTitle;
 
   return (
     <ScatterplotSubscriber
       {...props}
       loaders={loaders}
-      cellsData={[plotCells, cellsCount]}
+      cellsData={cellsData}
       useReadyData={[isReady, setItemIsReady, setItemIsNotReady, resetReadyItems]}
       urlsData={[urls, addUrl, resetUrls]}
       title={title}
-      mapping={plotMapping}
+      mapping={embeddingType}
       customOptions={customOptions}
-      hideTools={!mapping}
-      cellsEmptyMessage="Select a cell mapping in the settings."
+      hideTools={!embeddingType}
+      cellsEmptyMessage="Select an embedding type in the plot settings."
     />
   );
 }

--- a/src/components/embedding-scatterplot/EmbeddingScatterplotSubscriber.js
+++ b/src/components/embedding-scatterplot/EmbeddingScatterplotSubscriber.js
@@ -25,12 +25,14 @@ import { Component } from '../../app/constants';
    * @param {string} props.title An override value for the component title.
    * @param {number} props.averageFillDensity Override the average fill density calculation
    * when using dynamic opacity mode.
+   * @param {boolean} props.enableEmbeddingTypeSelection Should
+   * the dropdown to select an embedding type be displayed? By default, false.
    */
 export default function EmbeddingScatterplotSubscriber(props) {
   const {
     coordinationScopes,
     title: titleOverride,
-    enableEmbeddingTypeSelection = true,
+    enableEmbeddingTypeSelection = false,
   } = props;
 
   // Get "props" from the coordination space.

--- a/src/components/gating/GatingScatterplotOptions.js
+++ b/src/components/gating/GatingScatterplotOptions.js
@@ -43,7 +43,7 @@ export default function GatingScatterplotOptions(props) {
   };
 
   const handleTransformChange = (event) => {
-    setGatingFeatureValueTransform(event.target.value);
+    setGatingFeatureValueTransform(event.target.value === '' ? null : event.target.value);
   };
 
   // Feels a little hacky, but I think this is the best way to handle
@@ -61,7 +61,7 @@ export default function GatingScatterplotOptions(props) {
   };
 
   return (
-    [
+    <>
       <TableRow key="gene-option-row">
         <TableCell className={classes.labelCell}>
             Genes
@@ -84,7 +84,7 @@ export default function GatingScatterplotOptions(props) {
             ))}
           </OptionSelect>
         </TableCell>
-      </TableRow>,
+      </TableRow>
       <TableRow key="transform-option-row">
         <TableCell className={classes.labelCell}>
           Transform
@@ -93,20 +93,20 @@ export default function GatingScatterplotOptions(props) {
           <OptionSelect
             key="gating-transform-select"
             className={classes.select}
-            value={gatingFeatureValueTransform || ''}
+            value={gatingFeatureValueTransform === null ? '' : gatingFeatureValueTransform}
             onChange={handleTransformChange}
             inputProps={{
               id: 'scatterplot-transform-select',
             }}
           >
             {transformOptions.map(opt => (
-              <option key={opt.name} value={opt.value}>
+              <option key={opt.name} value={opt.value === null ? '' : opt.value}>
                 {opt.name}
               </option>
             ))}
           </OptionSelect>
         </TableCell>
-      </TableRow>,
+      </TableRow>
       <TableRow key="transform-coefficient-option-row">
         <TableCell className={classes.labelCell}>
               Transform Coefficient
@@ -122,7 +122,7 @@ export default function GatingScatterplotOptions(props) {
             }}
           />
         </TableCell>
-      </TableRow>,
-    ]
+      </TableRow>
+    </>
   );
 }

--- a/src/components/gating/GatingSubscriber.js
+++ b/src/components/gating/GatingSubscriber.js
@@ -49,7 +49,6 @@ export default function GatingSubscriber(props) {
     setGatingFeatureValueTransformCoefficient,
     setGatingFeatureSelectionX,
     setGatingFeatureSelectionY,
-
   }] = useCoordination(
     COMPONENT_COORDINATION_TYPES[Component.GATING],
     coordinationScopes,
@@ -67,7 +66,7 @@ export default function GatingSubscriber(props) {
   );
 
   const transformOptions = [
-    { name: 'None', value: '' },
+    { name: 'None', value: null },
     { name: 'Log', value: 'log1p' },
     { name: 'ArcSinh', value: 'arcsinh' }];
   const geneSelectOptions = expressionMatrix && expressionMatrix.cols ? expressionMatrix.cols : [];
@@ -76,7 +75,10 @@ export default function GatingSubscriber(props) {
   // eslint-disable-next-line no-console
   console.log([gatingFeatureSelectionX, gatingFeatureSelectionY].filter(v => v));
 
-  const mapping = `MAPPING_${gatingFeatureSelectionX}_${gatingFeatureSelectionY})`;
+  const mapping = (gatingFeatureSelectionX && gatingFeatureSelectionY
+    ? `MAPPING_${gatingFeatureSelectionX}_${gatingFeatureSelectionY})`
+    : null
+  );
 
   const title = useMemo(
     () => {
@@ -186,7 +188,7 @@ export default function GatingSubscriber(props) {
       title={title}
       customOptions={customOptions}
       hideTools={!(gatingFeatureSelectionX && gatingFeatureSelectionY)}
-      cellsEmptyMessage="Select two genes in the settings."
+      cellsEmptyMessage="Select two genes in the plot settings."
       getCellInfoOverride={getCellInfoOverride}
       cellSetsPolygonCacheId={polygonCacheId}
     />

--- a/src/components/gating/utils.js
+++ b/src/components/gating/utils.js
@@ -1,0 +1,30 @@
+
+export const VALUE_TRANSFORM_OPTIONS = [
+  { name: 'None', value: null },
+  { name: 'Log', value: 'log1p' },
+  { name: 'ArcSinh', value: 'arcsinh' },
+];
+/**
+ * Get a feature value transform function such as
+ * log1p or arcsinh.
+ * @param {string} featureValueTransform The function name.
+ * @param {number} coefficient The transform coefficient.
+ * @returns {function} The function which takes one number
+ * as a parameter and returns the transformed number
+ * (or the original number in the identity case).
+ */
+export function getValueTransformFunction(featureValueTransform, coefficient) {
+  // Set transform function
+  let transformFunction;
+  switch (featureValueTransform) {
+    case 'log1p':
+      transformFunction = v => Math.log(1 + v * coefficient);
+      break;
+    case 'arcsinh':
+      transformFunction = v => Math.asinh(v * coefficient);
+      break;
+    default:
+      transformFunction = v => v;
+  }
+  return transformFunction;
+}

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -141,6 +141,7 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
         getExpressionValue,
         getFillColor: [cellColorEncoding, cellSelection, cellColors],
         getLineColor: [cellColorEncoding, cellSelection, cellColors],
+        getPosition: [mapping],
         getCellIsSelected,
       },
       ...cellLayerDefaultProps(
@@ -318,7 +319,7 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
     }
 
     if ([
-      'cells', 'cellFilter', 'cellSelection', 'cellColors',
+      'cells', 'mapping', 'cellFilter', 'cellSelection', 'cellColors',
       'cellRadius', 'cellOpacity', 'cellRadiusMode', 'geneExpressionColormap',
       'geneExpressionColormapRange', 'geneSelection', 'cellColorEncoding',
     ].some(shallowDiff)) {

--- a/src/components/scatterplot/ScatterplotSubscriber.js
+++ b/src/components/scatterplot/ScatterplotSubscriber.js
@@ -202,7 +202,8 @@ export default function ScatterplotSubscriber(props) {
     && cache[namespace].find(el => isEqual(el[0], key))?.[1];
   const cellSetPolygons = useMemo(() => {
     const polygonCacheNamespace = `${mapping}${cellSetsPolygonCacheId}`;
-    if ((cellSetLabelsVisible || cellSetPolygonsVisible)
+    if (mapping
+        && (cellSetLabelsVisible || cellSetPolygonsVisible)
         && !cacheHas(cellSetPolygonCache, polygonCacheNamespace, cellSetSelection)
         && mergedCellSets?.tree?.length
         && Object.values(cells).length
@@ -232,7 +233,7 @@ export default function ScatterplotSubscriber(props) {
 
   const [xRange, yRange, xExtent, yExtent, numCells] = useMemo(() => {
     const cellValues = cells && Object.values(cells);
-    if (cellValues?.length) {
+    if (mapping && cellValues?.length) {
       const cellCoordinates = Object.values(cells)
         .map(c => c.mappings[mapping]);
       const xE = extent(cellCoordinates, c => c[0]);
@@ -301,7 +302,7 @@ export default function ScatterplotSubscriber(props) {
   const getExpressionValue = useExpressionValueGetter({ attrs, expressionData });
 
   let emptyMessage;
-  if (Object.keys(cells).length === 0 && cellsEmptyMessage) {
+  if ((numCells === 0 || !mapping) && cellsEmptyMessage) {
     emptyMessage = (
       <div>{cellsEmptyMessage}</div>
     );

--- a/src/components/sets/CellSetExpressionPlot.js
+++ b/src/components/sets/CellSetExpressionPlot.js
@@ -34,7 +34,7 @@ export default function CellSetExpressionPlot(props) {
     height,
     marginRight = 90,
     marginBottom,
-    useGeneExpressionTransform,
+    featureValueTransformName,
   } = props;
   // Get the max characters in an axis label for autsizing the bottom margin.
   const maxCharactersForLabel = data.reduce((acc, val) => {
@@ -151,10 +151,8 @@ export default function CellSetExpressionPlot(props) {
         orient: 'left',
         scale: 'yscale',
         zindex: 1,
-        // title: useGeneExpressionTransform
-        //   ? 'Log-Normalized Expression Values' : 'Normalized Expression Values',
-        title: useGeneExpressionTransform
-          ? ['Log-Transformed', 'Normalized Expression Values']
+        title: featureValueTransformName
+          ? [`${featureValueTransformName}-Transformed`, 'Normalized Expression Values']
           : 'Normalized Expression Values',
       },
       {

--- a/src/components/sets/CellSetExpressionPlot.js
+++ b/src/components/sets/CellSetExpressionPlot.js
@@ -21,8 +21,8 @@ import { colorArrayToString } from './utils';
  * @param {number} props.marginBottom The size of the margin
  * on the bottom of the plot, to account for long x-axis labels.
  * Default is allowing the component to automatically determine the margin.
- * @param {boolean} props.useGeneExpressionTransform Boolean representing
- * whether or not the expression values are log-transformed.
+ * @param {string|null} props.featureValueTransformName A name
+ * for the feature value transformation function.
  */
 export default function CellSetExpressionPlot(props) {
   const {

--- a/src/components/sets/CellSetExpressionPlotOptions.js
+++ b/src/components/sets/CellSetExpressionPlotOptions.js
@@ -1,29 +1,74 @@
 import React from 'react';
-import Checkbox from '@material-ui/core/Checkbox';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
+import TextField from '@material-ui/core/TextField';
 import { useStyles } from '../shared-plot-options/styles';
 import OptionsContainer from '../shared-plot-options/OptionsContainer';
+import OptionSelect from '../shared-plot-options/OptionSelect';
 
 export default function CellSetExpressionPlotOptions(props) {
-  const { toggleGeneExpressionTransform, useGeneExpressionTransform } = props;
+  const {
+    featureValueTransform,
+    setFeatureValueTransform,
+    featureValueTransformCoefficient,
+    setFeatureValueTransformCoefficient,
+    transformOptions,
+  } = props;
   const classes = useStyles();
 
-  function handleGeneExpressionTransformChange() {
-    toggleGeneExpressionTransform();
-  }
+  const handleTransformChange = (event) => {
+    setFeatureValueTransform(event.target.value === '' ? null : event.target.value);
+  };
+
+  // Feels a little hacky, but I think this is the best way to handle
+  // the limitations of the v4 material-ui number input.
+  const handleTransformCoefficientChange = (event) => {
+    const { value } = event.target;
+    if (!value) {
+      setFeatureValueTransformCoefficient(value);
+    } else {
+      const newCoefficient = Number(value);
+      if (!Number.isNaN(newCoefficient) && newCoefficient >= 0) {
+        setFeatureValueTransformCoefficient(value);
+      }
+    }
+  };
 
   return (
     <OptionsContainer>
       <TableRow>
-        <TableCell className={classes.labelCell}>Log Transform</TableCell>
+        <TableCell className={classes.labelCell}>Transform</TableCell>
         <TableCell className={classes.inputCell}>
-          <Checkbox
-            className={classes.checkbox}
-            checked={Boolean(useGeneExpressionTransform)}
-            onChange={handleGeneExpressionTransformChange}
-            name="scatterplot-option-cell-set-labels"
-            color="default"
+          <OptionSelect
+            key="gating-transform-select"
+            className={classes.select}
+            value={featureValueTransform === null ? '' : featureValueTransform}
+            onChange={handleTransformChange}
+            inputProps={{
+              id: 'scatterplot-transform-select',
+            }}
+          >
+            {transformOptions.map(opt => (
+              <option key={opt.name} value={opt.value === null ? '' : opt.value}>
+                {opt.name}
+              </option>
+            ))}
+          </OptionSelect>
+        </TableCell>
+      </TableRow>
+      <TableRow key="transform-coefficient-option-row">
+        <TableCell className={classes.labelCell}>
+          Transform Coefficient
+        </TableCell>
+        <TableCell className={classes.inputCell}>
+          <TextField
+            label="Number"
+            type="number"
+            onChange={handleTransformCoefficientChange}
+            value={featureValueTransformCoefficient}
+            InputLabelProps={{
+              shrink: true,
+            }}
           />
         </TableCell>
       </TableRow>

--- a/src/components/sets/hooks.js
+++ b/src/components/sets/hooks.js
@@ -17,6 +17,10 @@ import { treeToObjectsBySetNames, treeToSetSizesBySetNames } from './cell-set-ut
  * @param {array} geneSelection Array of selected genes.
  * @param {array} cellSetSelection Array of selected cell set paths.
  * @param {object[]} cellSetColor Array of objects with properties
+ * @param {string|null} featureValueTransform The name of the
+ * feature value transform function.
+ * @param {number} featureValueTransformCoefficient A coefficient
+ * to be used in the transform function.
  * @param {string} theme "light" or "dark" for the vitessce theme
  * `path` and `color`.
  */

--- a/src/components/sets/hooks.js
+++ b/src/components/sets/hooks.js
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { getValueTransformFunction } from '../gating/utils';
 import { mergeCellSets } from '../utils';
 import { treeToObjectsBySetNames, treeToSetSizesBySetNames } from './cell-set-utils';
 
@@ -21,7 +22,8 @@ import { treeToObjectsBySetNames, treeToSetSizesBySetNames } from './cell-set-ut
  */
 export function useExpressionByCellSet(
   expressionData, expressionDataAttrs, cellSets, additionalCellSets,
-  geneSelection, cellSetSelection, cellSetColor, useGeneExpressionTransform,
+  geneSelection, cellSetSelection, cellSetColor,
+  featureValueTransform, featureValueTransformCoefficient,
   theme,
 ) {
   const mergedCellSets = useMemo(
@@ -51,7 +53,10 @@ export function useExpressionByCellSet(
         const cellIndex = cellIndices[cell.obsId];
         const value = expressionData[0][cellIndex];
         const normValue = value * 100 / 255;
-        const transformedValue = useGeneExpressionTransform ? Math.log(1 + normValue) : normValue;
+        const transformFunction = getValueTransformFunction(
+          featureValueTransform, featureValueTransformCoefficient,
+        );
+        const transformedValue = transformFunction(normValue);
         exprMax = Math.max(transformedValue, exprMax);
         return { value: transformedValue, gene: firstGeneSelected, set: cell.name };
       });
@@ -59,7 +64,9 @@ export function useExpressionByCellSet(
     }
     return [null, null];
   }, [expressionData, expressionDataAttrs, geneSelection, theme,
-    mergedCellSets, cellSetSelection, cellSetColor, useGeneExpressionTransform]);
+    mergedCellSets, cellSetSelection, cellSetColor,
+    featureValueTransform, featureValueTransformCoefficient,
+  ]);
 
   // From the cell sets hierarchy and the list of selected cell sets,
   // generate the array of set sizes data points for the bar plot.

--- a/src/demo/configs.js
+++ b/src/demo/configs.js
@@ -1,6 +1,8 @@
 import { notPublic, vapi } from './utils';
 import {
-  justScatter, justScatterExpression, justSpatial, codeluppi2018,
+  justScatter, justScatterExpression, justSpatial,
+  codeluppi2018,
+  codeluppiGating,
 } from './view-configs/codeluppi';
 import { eng2019 } from './view-configs/eng';
 import { wang2018 } from './view-configs/wang';
@@ -46,6 +48,7 @@ export const configs = {
   'ome-ngff-v0.1': omeNgffLegacy,
   // Keys which enable backwards compatibility with old links.
   'linnarsson-2018': notPublic(codeluppi2018),
+  gating: codeluppiGating,
   vanderbilt: notPublic(spraggins2020),
   'dries-2019': notPublic(eng2019),
   ...coordinationTypeConfigs,

--- a/src/demo/view-configs/codeluppi.js
+++ b/src/demo/view-configs/codeluppi.js
@@ -301,6 +301,90 @@ export const codeluppi2018 = {
   ],
 };
 
+export const codeluppiGating = {
+  ...linnarssonBase,
+  public: true,
+  coordinationSpace: {
+    embeddingZoom: {
+      PCA: 0,
+      TSNE: 0.75,
+    },
+    embeddingType: {
+      PCA: 'PCA',
+      TSNE: 't-SNE',
+    },
+  },
+  layout: [
+    {
+      component: 'description',
+      props: {
+        description: `${linnarssonName}: ${linnarssonDescription}`,
+      },
+      x: 0,
+      y: 0,
+      w: 2,
+      h: 1,
+    },
+    {
+      component: 'status',
+      x: 0,
+      y: 5,
+      w: 2,
+      h: 1,
+    },
+    {
+      component: 'gating',
+      x: 2,
+      y: 0,
+      w: 4,
+      h: 4,
+    },
+    {
+      component: 'genes',
+      x: 9,
+      y: 0,
+      w: 3,
+      h: 2,
+    },
+    {
+      component: 'cellSets',
+      x: 9,
+      y: 3,
+      w: 3,
+      h: 2,
+    },
+    {
+      component: 'cellSetExpression',
+      x: 7,
+      y: 4,
+      w: 5,
+      h: 2,
+    },
+    {
+      component: 'scatterplot',
+      coordinationScopes: {
+        embeddingType: 'PCA',
+        embeddingZoom: 'PCA',
+      },
+      x: 6,
+      y: 0,
+      w: 3,
+      h: 2,
+    },
+    {
+      component: 'scatterplot',
+      coordinationScopes: {
+        embeddingType: 'TSNE',
+        embeddingZoom: 'TSNE',
+      },
+      x: 6,
+      y: 2,
+      w: 3,
+      h: 2,
+    },
+  ],
+};
+
 export const linnarssonWithRorb = {
   ...linnarssonBaseNoMolecules,
   coordinationSpace: {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { Heatmap } from './components/heatmap';
 import { Spatial } from './components/spatial';
-import { Scatterplot } from './components/base-scatterplot';
+import { Scatterplot } from './components/scatterplot';
 import VitessceGrid from './app/VitessceGrid';
 import {
   createApp,

--- a/src/schemas/config-1.0.14.schema.json
+++ b/src/schemas/config-1.0.14.schema.json
@@ -1,0 +1,1142 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/vitessce/vitessce/#dataset",
+  "title": "Vitessce data set",
+  "type": "object",
+  "definitions": {
+    "componentCoordinationScopeValue": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "components": {
+      "description": "The layout array defines the views, or components, rendered in the grid.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["component", "x", "y"],
+        "properties": {
+          "uid": {
+            "type": "string",
+            "description": "A unique identifier for the view, to refer to it in getter and setter functions in object-oriented contexts."
+          },
+          "component": {
+            "type": "string",
+            "description": "Specify a component using a name defined in the component registry."
+          },
+          "props": {
+            "type": "object",
+            "description": "Extra prop values for the component."
+          },
+          "x": { "type": "integer" },
+          "y": { "type": "integer" },
+          "w": { "type": "integer" },
+          "h": { "type": "integer" },
+          "coordinationScopes": {
+            "type": "object",
+            "description": "Component-level coordination scope mappings define which coordination object values a particular component can read and write, for each coordination type.",
+            "additionalProperties": true,
+            "required": [],
+            "properties": {
+              "dataset": {
+                "oneOf": [
+                  { "type": "string" },
+                  { "type": "array", "items": {"type": "string"} }
+                ]
+              },
+              "obsType": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureType": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureValueType": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingType": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingZoom": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingRotation": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingTargetX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingTargetY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingTargetZ": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingObsSetPolygonsVisible": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingObsSetLabelsVisible": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingObsSetLabelSize": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingObsRadius": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingObsOpacity": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingObsRadiusMode": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "embeddingObsOpacityMode": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialZoom": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialRotation": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialTargetX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialTargetY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialTargetZ": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialRotationX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialRotationY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialRotationZ": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialRotationOrbit": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialOrbitAxis": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialAxisFixed": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "heatmapZoomX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "heatmapZoomY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "heatmapTargetX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "heatmapTargetY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "obsFilter": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "obsHighlight": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "obsSetSelection": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "obsSetHighlight": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "obsSetColor": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureFilter": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureHighlight": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureSelection": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureValueTransform": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureValueColormap": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureValueColormapRange": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "obsColorEncoding": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialImageLayer": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialSegmentationLayer": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialPointLayer": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "spatialNeighborhoodLayer": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "genomicZoomX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "genomicZoomY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "genomicTargetX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "genomicTargetY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "gatingFeatureSelectionX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "gatingFeatureSelectionY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "gatingFeatureValueTransform": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "gatingFeatureValueTransformCoefficient": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "additionalObsSets": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "moleculeHighlight": { "$ref": "#/definitions/componentCoordinationScopeValue" }
+            }
+          }
+        }
+      }
+    },
+    "annDataCellSets": {
+      "type": "array",
+      "description": "Array of cell set configuration, following closely the conventions of the tabular schema",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["groupName", "setName"],
+        "properties": {
+          "groupName": {
+            "type": "string",
+            "description": "The display name for the set, like 'Cell Type' or 'Louvain.'"
+          },
+          "setName": {
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "The location in the AnnData store for the set, like 'obs/louvain' or 'obs/celltype.'"
+              },
+              {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "An array of locations in the AnnData store for a hierarchy of set names, from coarse to fine levels."
+              }
+            ]
+          },
+          "scoreName": {
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "The location in the AnnData store for the set confidence scores, like 'obs/celltype_prediction_score.'"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "annDataCells": {
+      "type": "object",
+      "description": "The properties of this object are the configuration for how to layout scatterplots and spatial information",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "required": [],
+      "properties": {
+        "xy": {
+          "type": "string",
+          "description": "The location in the AnnData store of cell centroids, like 'obsm/X_centroids.'"
+        },
+        "poly": {
+          "type": "string",
+          "description": "The location in the AnnData store of cell polygon outlines, like 'obsm/X_polygons.'"
+        },
+        "factors": {
+          "type": "array",
+          "description": "List of locations in the AnnData store of cell sets, like 'obs/louvain'",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mappings": {
+          "patternProperties": {
+            ".": {
+              "type": "object",
+              "description": "An object containing key-values for mappings like { UMAP: { key: 'obsm/X_umap', dims: [0, 1] } }.",
+              "additionalProperties": false,
+              "required": ["key"],
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "description": "Where to look in the AnnData store for this mapping, like 'obsm/X_umap.'"
+                },
+                "dims": {
+                  "type": "array",
+                  "description": "Which indices of the obsm object to take for a scatterplot, allowing for, for example, different PCs from obsm/X_pca",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": { "type": "number" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "annDataExpressionMatrix": {
+      "type": "object",
+      "description": "The properties of this object are the configuration for how to fetch the cell x genes matrix",
+      "additionalProperties": false,
+      "required": ["matrix"],
+      "properties": {
+        "matrix": {
+          "type": "string",
+           "description": "The location in the AnnData store of the cell x gene matrix, like 'obsm/hvg_subset.' or 'X'"
+        },
+        "geneFilter": {
+          "type": "string",
+           "description": "The location in the AnnData store of a filter for the genes if using a subset of the data, like 'var.highly_variable.' if the matrix comes from 'obsm/hvg_subset.'"
+        },
+        "matrixGeneFilter": {
+          "type": "string",
+           "description": "The location in the AnnData store of a filter for the matrix data (used in heatmap and histogram), like 'var.highly_variable.''"
+        },
+        "geneAlias": {
+          "type": "string",
+           "description": "The location in the AnnData store of a different list of names for gene list component, other than the `var` index"
+        }
+      }
+    },
+    "requestInit": {
+      "type": "object",
+      "description": "The properties of this object correspond to the parameters of the JavaScript fetch() function.",
+      "additionalProperties": false,
+      "required": [],
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object"
+        },
+        "body": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "cache": {
+          "type": "string"
+        },
+        "redirect": {
+          "type": "string"
+        },
+        "referrer": {
+          "type": "string"
+        },
+        "integrity": {
+          "type": "string"
+        }
+      }
+    },
+    "rasterLayer": {
+      "description": "The properties of this object are the rendering settings for the raster layer.",
+      "additionalProperties": false,
+      "required": ["channels", "colormap", "index", "opacity"],
+      "properties": {
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["selection"],
+            "properties": {
+              "color": {
+                "type": "array",
+                "items": { "type": "number" },
+                "description": "The color to use when rendering this channel under the null colormap."
+              },
+              "selection": {
+                "type": "object",
+                "description": "Determines the channel selection, e.g. some Z and time slice."
+              },
+              "slider": {
+                "type": "array",
+                "items": { "type": "number" },
+                "description": "Determines the range for color mapping."
+              },
+              "visible": {
+                "type": "boolean",
+                "description": "Determines whether this channel of the layer will be rendered in the spatial component."
+              }
+            }
+          }
+        },
+        "colormap": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "The name of the colormap to use for this layer."
+            },
+            {
+              "type": "null",
+              "description": "Use the solid color definitions."
+            }
+          ]
+        },
+        "transparentColor": {
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": { 
+                "type": "number",
+                "description": "One of R G or B (0 - 255)." 
+              },
+              "description": "Determines the color to be set to opacity 0"
+            },
+            {
+              "type": "null",
+              "description": "No selection."
+            }
+          ]
+        },
+        "index": {
+          "type": "number",
+          "description": "The index of the layer among the array of layers available in the image file."
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "modelMatrix": {
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 16,
+              "maxItems": 16,
+              "description": "transformation matrix for this layer"
+            },
+            {
+              "type": "null",
+              "description": "Use no transformation."
+            }
+          ]
+        },
+        "domainType": {
+          "type": "string",
+          "enum": ["Full", "Min/Max"],
+          "description": "Determines the extent of the channel slider input element in the layer controller."
+        },
+        "resolution": {
+          "type": "number",
+          "description": "Resolution of 3D volumetric rendering"
+        },
+        "xSlice": {
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "description": "Slice bounds"
+            },
+            {
+              "type": "null",
+              "description": "No slicing"
+            }
+          ]
+        },
+        "renderingMode": {
+          "type": "string",
+           "description": "Rendering mode of 3D volumetric rendering"
+        },
+        "ySlice": {
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "description": "Slice bounds"
+            },
+            {
+              "type": "null",
+              "description": "No slicing"
+            }
+          ]
+        },
+        "zSlice": {
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "description": "Slice bounds"
+            },
+            {
+              "type": "null",
+              "description": "No slicing"
+            }
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": ["raster", "bitmask"]
+        },
+        "use3d": {
+          "type": "boolean"
+        },
+        "visible": {
+          "type": "boolean",
+          "description": "Determines whether this entire layer will be rendered in the spatial component."
+        }
+      }
+    },
+    "moleculesLayer": {
+      "type": "object",
+      "description": "The properties of this object are the rendering settings for the molecules layer.",
+      "additionalProperties": false,
+      "required": ["visible", "radius", "opacity"],
+      "properties": {
+        "visible": {
+          "type": "boolean"
+        },
+        "radius": {
+          "type": "number"
+        },
+        "opacity": {
+          "type": "number"
+        }
+      }
+    },
+    "cellsLayer": {
+      "type": "object",
+      "description": "The properties of this object are the rendering settings for the cells layer.",
+      "additionalProperties": false,
+      "required": ["visible", "stroked", "radius", "opacity"],
+      "properties": {
+        "visible": {
+          "type": "boolean"
+        },
+        "stroked": {
+          "type": "boolean"
+        },
+        "radius": {
+          "type": "number"
+        },
+        "opacity": {
+          "type": "number"
+        }
+      }
+    },
+    "neighborhoodsLayer": {
+      "type": "object",
+      "description": "The properties of this object are the rendering settings for the neighborhoods layer.",
+      "additionalProperties": false,
+      "required": ["visible"],
+      "properties": {
+        "visible": {
+          "type": "boolean"
+        }
+      }
+    },
+    "spatialImageLayer": {
+      "type": "array",
+      "description": "Array of Spatial Layers",
+      "items": {
+        "$ref": "#/definitions/rasterLayer"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["version", "name", "datasets", "layout", "initStrategy"],
+  "properties": {
+    "name": { "type": "string" },
+    "public": { "type": "boolean" },
+    "description": { "type": "string" },
+    "datasets": {
+      "type": "array",
+      "description": "The datasets array defines groups of files, where the files within each dataset reference the same entities (cells, genes, cell sets, etc).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["uid", "files"],
+        "properties": {
+          "uid": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["fileType"],
+              "properties": {
+                "name": { "type": "string" },
+                "type": { "type": "string" },
+                "fileType": { "type": "string" },
+                "url": { "type": "string" },
+                "options": { "oneOf": [{ "$ref": "#/definitions/annDataCellSets" }, { "$ref": "https://github.com/vitessce/vitessce/#raster" }, { "$ref": "#/definitions/annDataCells" }, { "$ref": "#/definitions/annDataExpressionMatrix" }] },
+                "requestInit": { "$ref": "#/definitions/requestInit" },
+                "coordinationValues": {
+                  "type": "object",
+                  "description": "Keys are coordination types. Values are coordination values. Used for matching views to files.",
+                  "patternProperties": {
+                    ".": {
+                      "oneOf": [
+                        { "type": "string" }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "coordinationSpace": {
+      "type": "object",
+      "description": "The coordination space stores the values for each scope of each coordination object.",
+      "additionalProperties": true,
+      "required": [],
+      "properties": {
+        "dataset": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "string" }
+          }
+        },
+        "obsType": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "string" }
+          }
+        },
+        "featureType": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "string" }
+          }
+        },
+        "featureValueType": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "string" }
+          }
+        },
+        "embeddingZoom": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "embeddingRotation": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "embeddingTargetX": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "embeddingTargetY": {
+          "type": "object",
+          "patternProperties": {
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "embeddingTargetZ": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "embeddingType": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "string" }
+          }
+        },
+        "embeddingObsSetPolygonsVisible": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "boolean" }
+          }
+        },
+        "embeddingObsSetLabelsVisible": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "boolean" }
+          }
+        },
+        "embeddingObsSetLabelSize": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "embeddingObsRadius": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "type": "number",
+              "description": "The cell radius value, used when embeddingCellRadiusMode is absolute or relative."
+            }
+          }
+        },
+        "embeddingObsOpacity": {
+          "type": "object",
+          "patternProperties": {
+              ".": {
+                "type": "number",
+                "description": "The cell opacity value, used when embeddingCellOpacityMode is static."
+              }
+          }
+        },
+        "embeddingObsRadiusMode": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "type": "string",
+              "enum": ["manual", "auto"],
+              "description": "Should data points representing cells be assigned a static (manual) or dynamic (auto, based on zoom level and data extent) radius?"
+            }
+          }
+        },
+        "embeddingObsOpacityMode": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "type": "string",
+              "enum": ["manual", "auto"],
+              "description": "Should data points representing cells be assigned a static (manual) or dynamic (auto, based on zoom level and data extent) opacity?"
+            }
+          }
+        },
+        "spatialZoom": {
+          "type": "object",
+          "patternProperties": {
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "spatialRotation": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "spatialTargetX": {
+          "type": "object",
+          "patternProperties": {
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "spatialTargetY": {
+          "type": "object",
+          "patternProperties": {
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "spatialTargetZ": {
+          "type": "object",
+          "patternProperties": {
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "spatialRotationX": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set. Only useful for 3D viewing."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "spatialRotationY": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set. Only useful for 3D viewing."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "spatialRotationZ": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set. Only useful for 3D viewing."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+         "spatialRotationOrbit": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set. Only useful for 3D viewing."
+                },
+                { "type": "number" }
+              ]
+            }
+          }
+        },
+        "spatialOrbitAxis": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set. Only useful for 3D viewing."
+                },
+                { "type": "string" }
+              ]
+            }
+          }
+        },
+        "spatialAxisFixed": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "Whether or not to have a fixed axis for the camera. Only useful for 3D viewing."
+                },
+                { "type": "boolean" }
+              ]
+            }
+          }
+        },
+        "spatialImageLayer": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided and auto layer initialization is enabled, layers will be automatically initialized."
+                },
+                { "$ref": "#/definitions/spatialImageLayer" }
+              ]
+            }
+          }
+        },
+        "spatialSegmentationLayer": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided and auto layer initialization is enabled, layers will be automatically initialized."
+                },
+                { "$ref": "#/definitions/cellsLayer" }
+              ]
+            }
+          }
+        },
+        "spatialNeighborhoodLayer": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided and auto layer initialization is enabled, layers will be automatically initialized."
+                },
+                { "$ref": "#/definitions/neighborhoodsLayer" }
+              ]
+            }
+          }
+        },
+        "spatialPointLayer": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided and auto layer initialization is enabled, layers will be automatically initialized."
+                },
+                { "$ref": "#/definitions/moleculesLayer" }
+              ]
+            }
+          }
+        },
+        "heatmapZoomX": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "heatmapZoomY": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "heatmapTargetX": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "heatmapTargetY": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "obsFilter": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, no cells will be filtered out initially."
+                },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            }
+          }
+        },
+        "obsHighlight": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, no cell will be highlighted initially."
+                },
+                { "type": "string" }
+              ]
+            }
+          }
+        },
+        "obsSetSelection": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided and auto cell set initialization is enabled, cell set selections will be automatically initialized."
+                },
+                { "type": "array" }
+              ]
+            }
+          }
+        },
+        "obsSetHighlight": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, no cell sets will be highlighted initially."
+                },
+                { "type": "string" }
+              ]
+            }
+          }
+        },
+        "obsSetColor": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, cell set colors will be automatically initialized."
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["path", "color"],
+                    "properties": {
+                      "path": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "color": {
+                        "type": "array",
+                        "items": { "type": "number" }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "obsColorEncoding": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "type": "string",
+              "enum": ["geneSelection", "cellSetSelection"],
+              "description": "How should data points representing cells be colored?"
+            }
+          }
+        },
+        "featureFilter": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, no genes will be filtered out initially."
+                },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            }
+          }
+        },
+        "featureHighlight": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, no genes will be highlighted initially."
+                },
+                { "type": "string" }
+              ]
+            }
+          }
+        },
+        "featureSelection": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            }
+          }
+        },
+        "featureValueTransform": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                { "type": "string", "pattern": "log1p" }
+              ]
+            }
+          }
+        },
+        "featureValueColormap": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "string" }
+          }
+        },
+        "featureValueColormapRange": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "array", "items": { "type": "number" } }
+          }
+        },
+        "genomicZoomX": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "genomicZoomY": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "genomicTargetX": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "genomicTargetY": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "gatingFeatureSelectionX": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "oneOf": [
+             { "type": "string" },
+             { "type": "null" }
+            ] }
+          }
+        },
+        "gatingFeatureSelectionY": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "oneOf": [
+             { "type": "string" },
+             { "type": "null" }
+            ] }
+          }
+        },
+        "gatingFeatureValueTransform": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "oneOf": [
+             { "type": "string" },
+             { "type": "null" }
+            ] }
+          }
+        },
+        "gatingFeatureValueTransformCoefficient": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
+          }
+        },
+        "additionalObsSets": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, no cell will be highlighted initially."
+                },
+                {
+                  "$ref": "https://github.com/vitessce/vitessce/#cell-sets"
+                }
+              ]
+            }
+          }
+        },
+        "moleculeHighlight": {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, no molecule will be highlighted initially."
+                },
+                { "type": "string" }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "layout": { "$ref": "#/definitions/components" },
+    "initStrategy": {
+      "type": "string",
+      "enum": ["none", "auto"],
+      "description": "The initialization strategy determines how missing coordination objects and coordination scope mappings are initially filled in."
+    },
+    "version": {
+      "type": "string",
+      "enum": ["1.0.14"],
+      "description": "The schema version for the view config."
+    }
+  }
+}

--- a/src/schemas/config-1.0.14.schema.json
+++ b/src/schemas/config-1.0.14.schema.json
@@ -91,6 +91,7 @@
               "featureHighlight": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "featureSelection": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "featureValueTransform": { "$ref": "#/definitions/componentCoordinationScopeValue" },
+              "featureValueTransformCoefficient": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "featureValueColormap": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "featureValueColormapRange": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "obsColorEncoding": { "$ref": "#/definitions/componentCoordinationScopeValue" },
@@ -104,8 +105,6 @@
               "genomicTargetY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "gatingFeatureSelectionX": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "gatingFeatureSelectionY": { "$ref": "#/definitions/componentCoordinationScopeValue" },
-              "gatingFeatureValueTransform": { "$ref": "#/definitions/componentCoordinationScopeValue" },
-              "gatingFeatureValueTransformCoefficient": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "additionalObsSets": { "$ref": "#/definitions/componentCoordinationScopeValue" },
               "moleculeHighlight": { "$ref": "#/definitions/componentCoordinationScopeValue" }
             }
@@ -1021,9 +1020,15 @@
                 {
                   "type": "null"
                 },
-                { "type": "string", "pattern": "log1p" }
+                { "type": "string", "enum": ["log1p", "arcsinh"] }
               ]
             }
+          }
+        },
+        "featureValueTransformCoefficient": {
+          "type": "object",
+          "patternProperties": {
+            ".": { "type": "number" }
           }
         },
         "featureValueColormap": {
@@ -1078,21 +1083,6 @@
              { "type": "string" },
              { "type": "null" }
             ] }
-          }
-        },
-        "gatingFeatureValueTransform": {
-          "type": "object",
-          "patternProperties": {
-            ".": { "oneOf": [
-             { "type": "string" },
-             { "type": "null" }
-            ] }
-          }
-        },
-        "gatingFeatureValueTransformCoefficient": {
-          "type": "object",
-          "patternProperties": {
-            ".": { "type": "number" }
           }
         },
         "additionalObsSets": {

--- a/src/schemas/config-1.0.14.schema.test.js
+++ b/src/schemas/config-1.0.14.schema.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import { CoordinationType } from '../app/constants';
-import viewConfigSchema from './config-1.0.13.schema.json';
+import viewConfigSchema from './config-1.0.14.schema.json';
 
 describe('view config schema', () => {
   describe('coordination types', () => {


### PR DESCRIPTION
Hi @rj3d,
This is a PR into your PR branch.

Based on your comment in #1299
> I created a separate coordination for the gating transform/transform coefficient for the gating component. Long term I'd like to combine it with the global gating transform, but adding new transforms to the CellSetExpressionPlot seemed out of the scope of this PR. If this is cool with you, I'll create a new feature request to combine them.

I merged the transform coordination types. Since it can be pretty tricky to remove coordination types once they have been added, it is preferable to me to implement support for `arcsinh` in the other places where the transform is used rather than adding a gating-specific coordination type.

I modified your code a little bit, added a demo at http://localhost:3000/?dataset=gating, and added a new view config schema (because we modified the coordination types which are validated via the view config schema).

Please let me know if these changes are acceptable to you, and if so, we can merge this PR followed by merging #1299.